### PR TITLE
fix/cors-allow-network-ip: add 192.168.1.186:4200 to allowed origins

### DIFF
--- a/internal/http/cors.go
+++ b/internal/http/cors.go
@@ -15,6 +15,7 @@ func NewCORSMiddleware() func(http.Handler) http.Handler {
 			"http://127.0.0.1:3000",
 			"http://127.0.0.1:3001",
 			"http://127.0.0.1:4200",
+			"http://192.168.1.186:4200",
 			"https://satanlittlehelper.github.io",
 		},
 		AllowedMethods: []string{


### PR DESCRIPTION
- Add network IP address to CORS allowed origins list
- Fixes CORS error for Angular app running on network IP
- Allows frontend to make requests from 192.168.1.186:4200